### PR TITLE
Updated project to netcoreapp2.2 and language version latest.

### DIFF
--- a/CatFactory.SqlServer.Tests/CatFactory.SqlServer.Tests.csproj
+++ b/CatFactory.SqlServer.Tests/CatFactory.SqlServer.Tests.csproj
@@ -1,25 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0"/>
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.1"/>
+        <PackageReference Include="System.Data.SqlClient" Version="4.6.0"/>
+        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\CatFactory.SqlServer\CatFactory.SqlServer.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\CatFactory.SqlServer\CatFactory.SqlServer.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/CatFactory.SqlServer/CatFactory.SqlServer.csproj
+++ b/CatFactory.SqlServer/CatFactory.SqlServer.csproj
@@ -1,31 +1,36 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <Version>1.0.0-beta-sun-build32</Version>
-    <Authors>H. Herzl</Authors>
-    <Company>Herzl Corp.</Company>
-    <Description>CatFactory package for SQL Server</Description>
-    <RepositoryUrl>https://github.com/hherzl/CatFactory.SqlServer</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>SQL Server Scaffolding Stored Procedures</PackageTags>
-    <PackageReleaseNotes>1.0.0-beta-sun-build32 Version:
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Version>1.0.0-beta-sun-build32</Version>
+        <Authors>H. Herzl</Authors>
+        <Company>Herzl Corp.</Company>
+        <Description>CatFactory package for SQL Server</Description>
+        <RepositoryUrl>https://github.com/hherzl/CatFactory.SqlServer</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>SQL Server Scaffolding Stored Procedures</PackageTags>
+        <PackageReleaseNotes>1.0.0-beta-sun-build32 Version:
 
-* Core package update
+            * Core package update
 
-Wiki: https://github.com/hherzl/CatFactory.SqlServer/wiki
-</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/hherzl/CatFactory.SqlServer</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/hherzl/CatFactory.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
-  </PropertyGroup>
+            Wiki: https://github.com/hherzl/CatFactory.SqlServer/wiki
+        </PackageReleaseNotes>
+        <PackageProjectUrl>https://github.com/hherzl/CatFactory.SqlServer</PackageProjectUrl>
+        <PackageLicenseUrl>https://github.com/hherzl/CatFactory.SqlServer/blob/master/LICENSE</PackageLicenseUrl>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netcoreapp2.0\CatFactory.SqlServer.xml</DocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DocumentationFile>bin\Debug\netcoreapp2.0\CatFactory.SqlServer.xml</DocumentationFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="CatFactory" Version="1.0.0-beta-sun-build20" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\CatFactory\CatFactory\CatFactory.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CatFactory.SqlServer/SqlServerDatabaseFactory.cs
+++ b/CatFactory.SqlServer/SqlServerDatabaseFactory.cs
@@ -376,19 +376,20 @@ namespace CatFactory.SqlServer
         /// <returns>An instance of <see cref="Database"/> class that represents a database from SQL Server instance</returns>
         public virtual Database Import()
         {
-            var database = new Database
-            {
-                DefaultSchema = "dbo",
-                SupportTransactions = true,
-                DatabaseTypeMaps = DatabaseTypeMaps.ToList(),
-                NamingConvention = new SqlServerDatabaseNamingConvention()
-            };
-
+            Database database;
             using (var connection = GetConnection())
             {
-                connection.Open();
+                database = new Database
+                {
+                    DataSource = connection.DataSource,
+                    Name = connection.Database,
+                    DefaultSchema = "dbo",
+                    SupportTransactions = true,
+                    DatabaseTypeMaps = this.DatabaseTypeMaps.ToList(),
+                    NamingConvention = new SqlServerDatabaseNamingConvention()
+                };
 
-                database.Name = connection.Database;
+                connection.Open();
 
                 SqlServerDatabaseFactoryHelper.AddUserDefinedDataTypes(database, connection);
 
@@ -546,6 +547,8 @@ namespace CatFactory.SqlServer
                     {
                         yield return new DbObject
                         {
+                            DataSource = connection.DataSource,
+                            Catalog = connection.Database,
                             Schema = dataReader.GetString(0),
                             Name = dataReader.GetString(1),
                             Type = dataReader.GetString(2)
@@ -569,6 +572,8 @@ namespace CatFactory.SqlServer
                 {
                     var table = new Table
                     {
+                        DataSource = connection.DataSource,
+                        Catalog = connection.Database,
                         Schema = dbObject.Schema,
                         Name = dbObject.Name
                     };
@@ -918,6 +923,8 @@ namespace CatFactory.SqlServer
                 {
                     var view = new View
                     {
+                        DataSource = connection.DataSource,
+                        Catalog = connection.Database,
                         Schema = dbObject.Schema,
                         Name = dbObject.Name
                     };
@@ -1012,6 +1019,8 @@ namespace CatFactory.SqlServer
                 {
                     var scalarFunction = new ScalarFunction
                     {
+                        DataSource = connection.DataSource,
+                        Catalog = connection.Database,
                         Schema = dbObject.Schema,
                         Name = dbObject.Name
                     };
@@ -1084,6 +1093,8 @@ namespace CatFactory.SqlServer
                 {
                     var tableFunction = new TableFunction
                     {
+                        DataSource = connection.DataSource,
+                        Catalog = connection.Database,
                         Schema = dbObject.Schema,
                         Name = dbObject.Name
                     };
@@ -1160,6 +1171,8 @@ namespace CatFactory.SqlServer
                 {
                     var storedProcedure = new StoredProcedure
                     {
+                        DataSource = connection.DataSource,
+                        Catalog = connection.Database,
                         Schema = dbObject.Schema,
                         Name = dbObject.Name
                     };

--- a/CatFactory.SqlServer/SqlServerDatabaseFactoryImport.cs
+++ b/CatFactory.SqlServer/SqlServerDatabaseFactoryImport.cs
@@ -150,6 +150,8 @@ namespace CatFactory.SqlServer
 
                 var database = new Database
                 {
+                    DataSource = connection.DataSource,
+                    Catalog = connection.Database,
                     Name = connection.Database
                 };
 


### PR DESCRIPTION
Utilizes ProjectReference instead of PackageReference due to development.

Updated project to netcoreapp2.2 and language version latest.

Due to errors matching three part database object name to two part database object name from Database Catalog Upper/Lower case not matching. Refactored DbObject to have DataSource and Catalog properties enabling more precision name matching. Modified Database to have DataSoruce and Catalog properties.

Database Catalog case different on my database than on test database. Added TODO refactor to work with case sensitive database and/or collations as indicated by the data

All Tests Pass